### PR TITLE
Added check for pending reboot at the beginning and end of set-target

### DIFF
--- a/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
+++ b/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
@@ -138,12 +138,12 @@ function Set-TargetResource
     $uri, $kbId = Validate-StandardArguments -Path $Path -Id $Id
 
     #check if there is currently an update pending, if so error
-	Write-Verbose "Checking wusa for pending reboots"
-	$wua = New-Object -ComObject Microsoft.Update.SystemInfo
-	if($wua.RebootRequired)
-	{
-		Throw "There is a prior reboot pending. This prevents wusa from being able to install $Id."
-	}
+    Write-Verbose "Checking wusa for pending reboots"
+    $wua = New-Object -ComObject Microsoft.Update.SystemInfo
+    if($wua.RebootRequired)
+    {
+        Throw "There is a prior reboot pending. This prevents wusa from being able to install $Id."
+    }
             
     if($Ensure -eq 'Present')
     {
@@ -179,7 +179,7 @@ function Set-TargetResource
     }
     
     if($wua.RebootRequired)
-	{
+    {
         # reboot machine if wusa indicates reboot.
         $global:DSCMachineStatus = 1        
     }

--- a/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
+++ b/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
@@ -137,7 +137,13 @@ function Set-TargetResource
     }
     $uri, $kbId = Validate-StandardArguments -Path $Path -Id $Id
 
-    
+    #check if there is currently an update pending, if so error
+	Write-Verbose "Checking wusa for pending reboots"
+	$wua = New-Object -ComObject Microsoft.Update.SystemInfo
+	if($wua.RebootRequired)
+	{
+		Throw "There is a prior reboot pending. This prevents wusa from being able to install $Id."
+	}
             
     if($Ensure -eq 'Present')
     {
@@ -170,18 +176,13 @@ function Set-TargetResource
         }
 
         Write-Verbose "$($LocalizedData.EndKeyWord) $($LocalizedData.ActionUninstallUsingwsusa)"
-
-        
     }
     
-    if ($LASTEXITCODE -eq 3010)
-    {
-        # reboot machine if exitcode indicates reboot.
-        # This seems to be broken
+    if($wua.RebootRequired)
+	{
+        # reboot machine if wusa indicates reboot.
         $global:DSCMachineStatus = 1        
     }
-            
-    
 }
 
 


### PR DESCRIPTION
Queries from the wuapi system information interface for pending reboots. Checks before running wusa with the specified update, and throws error if a pending reboot is found. Checks after running wusa and sets the LCM reboot status if a pending reboot is found. 
