### PR TITLE
Fixes Get-TargetResource and Set-TargetResource function

### DIFF
--- a/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
+++ b/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
@@ -172,7 +172,7 @@ function Set-TargetResource
         
     }
     
-    if ([bool](Get-Variable -Name 'LASTEXITCODE' -ErrorAction 'SilentlyContinue'))
+    if (Test-Path -Path 'variable:\LASTEXITCODE')
     {
         if ($LASTEXITCODE -eq 3010)
         {

--- a/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
+++ b/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
@@ -64,10 +64,8 @@ function Get-TargetResource
     $uri, $kbId = Validate-StandardArguments -Path $Path -Id $Id
 
     Write-Verbose $($LocalizedData.GettingHotfixMessage -f ${Id})
-    
-    $PSBoundParameters.Remove('Id')
 
-    $hotfix = Get-HotFix -Id "KB$kbId" @PSBoundParameters
+    $hotfix = Get-HotFix -Id "KB$kbId"
     
     $returnValue = @{
         Path = ''

--- a/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
+++ b/DscResources/MSFT_xWindowsUpdate/MSFT_xWindowsUpdate.psm1
@@ -172,14 +172,14 @@ function Set-TargetResource
         
     }
     
-    if ($LASTEXITCODE -eq 3010)
+    if ([bool](Get-Variable -Name 'LASTEXITCODE' -ErrorAction 'SilentlyContinue'))
     {
-        # reboot machine if exitcode indicates reboot.
-        # This seems to be broken
-        $global:DSCMachineStatus = 1        
+        if ($LASTEXITCODE -eq 3010)
+        {
+            # reboot machine if exitcode indicates reboot.
+            $global:DSCMachineStatus = 1        
+        }
     }
-            
-    
 }
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If no log is used, a temporary log name is created by the resource.
 
 ### Unreleased Version
 
-* MSFT_xWindowsUpdate: Fixed an issue in the Get-TargetResource function, resulting in the Get-DscConfiguration cmdlet now working appropriately.
+* MSFT_xWindowsUpdate: Fixed an issue in the Get-TargetResource function, resulting in the Get-DscConfiguration cmdlet now working appropriately when the resource is applied.
 * MSFT_xWindowsUpdate: Fixed an issue in the Set-TargetResource function that was causing the function to fail when the installation of a hotfix did not provide an exit code.
 
 ### 2.2.0.0

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ If no log is used, a temporary log name is created by the resource.
 
 ### Unreleased Version
 
-* MSFT_xWindowsUpdate: Fixed an issue in the Get-TargetResource function, resulting in the Get-DscConfiguration cmdlet working appropriately for the resource.
-* MSFT_xWindowsUpdate: Fixed an issue in the Set-TargetResource function that was causing it to fail when the installation of a hotfix did not provide an exit code.
+* MSFT_xWindowsUpdate: Fixed an issue in the Get-TargetResource function, resulting in the Get-DscConfiguration cmdlet now working appropriately.
+* MSFT_xWindowsUpdate: Fixed an issue in the Set-TargetResource function that was causing the function to fail when the installation of a hotfix did not provide an exit code.
 
 ### 2.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ If no log is used, a temporary log name is created by the resource.
 
 ## Versions
 
+### Unreleased Version
+
+* MSFT_xWindowsUpdate: Fixed an issue in the Get-TargetResource function, resulting in the Get-DscConfiguration cmdlet working appropriately for the resource.
+* MSFT_xWindowsUpdate: Fixed an issue in the Set-TargetResource function that was causing it to fail when the installation of a hotfix did not provide an exit code.
+
 ### 2.2.0.0
 
 * Minor fixes


### PR DESCRIPTION
The Get-TargetResource function would fail because Get-HotFix was receiving the Path parameter which it does not take.

Also, when $LASTEXITCODE was not set, it would cause the Set-TargetResource function to fail. Adding a check to make sure the variable exists before using it fixed this issue.
