### PR TITLE
xWindowsUpdateAgent: Fix Get-TargetResource returning incorrect key - Fixes #55

### DIFF
--- a/DscResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
+++ b/DscResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
@@ -399,7 +399,7 @@ function Get-TargetResource
                         TotalUpdatesNotInstalled = $totalUpdatesNotInstalled 
                         RebootRequired = $rebootRequired
                         Notifications = $notificationLevel
-                        Service = $SourceReturn
+                        Source = $SourceReturn
                         UpdateNow = $UpdateNowReturn
                     }
     $returnValue

--- a/DscResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
+++ b/DscResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
@@ -443,7 +443,7 @@ function Set-TargetResource
     Write-Verbose "updateNow compliant: $updateCompliant"
     $notificationCompliant = (!$Notifications -or $Notifications -eq $Get.Notifications)
     Write-Verbose "notifications compliant: $notificationCompliant"
-    $SourceCompliant = (!$Source -or $Source -eq $Get.Service)
+    $SourceCompliant = (!$Source -or $Source -eq $Get.Source)
     Write-Verbose "service compliant: $notificationCompliant"
 
             If(!$updateCompliant -and $PSCmdlet.ShouldProcess("Install Updates"))
@@ -549,7 +549,7 @@ function Test-TargetResource
     Write-Verbose "updateNow compliant: $updateCompliant"
     $notificationCompliant = (!$Notifications -or $Notifications -eq $Get.Notifications)
     Write-Verbose "notifications compliant: $notificationCompliant"
-    $SourceCompliant = (!$Source -or $Source -eq $Get.Service)
+    $SourceCompliant = (!$Source -or $Source -eq $Get.Source)
     Write-Verbose "service compliant: $notificationCompliant"
     If($updateCompliant -and $notificationCompliant -and $SourceCompliant)
     {

--- a/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
@@ -1587,6 +1587,58 @@ try
             }
         }
 
+        Describe "$($Global:DSCResourceName)\Test-TargetResourceProperties" {
+            Mock -CommandName Write-Warning -MockWith {} -Verifiable
+            Mock -CommandName Write-Verbose -MockWith {}
+
+            It 'Calls write-warning when no categories are passed' {
+                $PropertiesToTest = @{
+                    IsSingleInstance = 'Yes'
+                    Notifications = 'Disabled'
+                    Source = 'WindowsUpdate'
+                    Category = @()
+                    UpdateNow = $True
+                }
+                Test-TargetResourceProperties @PropertiesToTest
+
+                Assert-MockCalled -CommandName Write-Warning -Times 1 -Exactly -Scope It
+            }
+            
+            It 'Calls write-warning when Important updates are requested but not Security updates' {
+                $PropertiesToTest = @{
+                    IsSingleInstance = 'Yes'
+                    Notifications = 'Disabled'
+                    Source = 'WindowsUpdate'
+                    Category = 'Important'
+                }
+                Test-TargetResourceProperties @PropertiesToTest
+
+                Assert-MockCalled -CommandName Write-Warning -Times 1 -Exactly -Scope It
+            }
+
+            It 'Calls write-warning when Optional updates are requested but not Security updates' {
+                $PropertiesToTest = @{
+                    IsSingleInstance = 'Yes'
+                    Notifications = 'Disabled'
+                    Source = 'WindowsUpdate'
+                    Category = 'Optional'
+                    UpdateNow = $True
+                }
+                Test-TargetResourceProperties @PropertiesToTest
+
+                Assert-MockCalled -CommandName Write-Verbose -Times 1 -Exactly -Scope It
+            }
+
+            It 'Throws an exception when passed WSUS as a source' {
+                $PropertiesToTest = @{
+                    IsSingleInstance = 'Yes'
+                    Category = 'Security'
+                    Notifications = 'Disabled'
+                    Source = 'WSUS'
+                }
+                {Test-TargetResourceProperties @PropertiesToTest} | Should Throw
+            }
+        }
     }
 
     #endregion

--- a/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
@@ -1639,6 +1639,30 @@ try
                 {Test-TargetResourceProperties @PropertiesToTest} | Should Throw
             }
         }
+
+        Describe "$($Global:DSCResourceName)\Get-WuaAuNotificationLevelInt" {
+            It 'Gets int for notification level of Not Configured' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'Not Configured' | Should be 0
+            }
+            It 'Gets int for notification level of Disabled' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'Disabled' | Should be 1
+            }
+            It 'Gets int for notification level of Notify before download' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'Notify before download' | Should be 2
+            }
+            It 'Gets int for notification level of Notify before installation' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'Notify before installation' | Should be 3
+            }
+            It 'Gets int for notification level of Scheduled Installation' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'Scheduled Installation' | Should be 4
+            }
+            It 'Gets int for notification level of ScheduledInstallation' {
+                Get-WuaAuNotificationLevelInt -notificationLevel 'ScheduledInstallation' | Should be 4
+            }
+            It 'Gets int for notification level when nothing is provided' {
+                { Get-WuaAuNotificationLevelInt } | Should Throw
+            }
+        }
     }
 
     #endregion

--- a/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
@@ -42,7 +42,7 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $Global:DSCResourceName {
-
+        
         #region Pester Test Initialization
         $Global:mockedSearchResultWithUpdate = [PSCustomObject] @{
             Updates = @{
@@ -149,8 +149,8 @@ try
                 it 'should return UpdateNome=$true'{
                     $getResult.UpdateNow | should be $true
                 }
-                it 'should return Service=MU'{
-                    $getResult.Service | should be "MicrosoftUpdate"
+                it 'should return Source=MU'{
+                    $getResult.Source | should be "MicrosoftUpdate"
                 }
 
                 it 'should have called the mock' {
@@ -203,8 +203,8 @@ try
                 it 'should return UpdateNome=$true'{
                     $getResult.UpdateNow | should be $true
                 }
-                it 'should return Service=WU'{
-                    $getResult.Service | should be "WindowsUpdate"
+                it 'should return Source=WU'{
+                    $getResult.Source | should be "WindowsUpdate"
                 }
 
                 it 'should have called the mock' {


### PR DESCRIPTION
Get-TargetResource was returning the Source (WindowsUpdate/MicrosoftUpdate) under a key of 'Service' instead of 'Source' as the property is named. This was causing Get-DscConfiguration to fail (as seen in #55 ).

This fixes that incorrect key and the places it's used, tests are also updated to correctly expect that value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwindowsupdate/56)
<!-- Reviewable:end -->
