### PR TITLE
Update tests to use Assert-VerifiableMock

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Please check out common DSC Resources
 
 ### Unreleased
 
+* Tests no longer fail on `Assert-VerifiableMocks`, these are now renamed
+  to `Assert-VerifiableMock` (breaking change in Pester v4).
+
 ### 2.7.0.0
 
 * xWindowsUpdateAgent: Fix Get-TargetResource returning incorrect key

--- a/Tests/Unit/MSFT_xWindowsUpdate.tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsUpdate.tests.ps1
@@ -49,7 +49,7 @@ try
                 $getResult = (Get-TargetResource -Path 'C:\test.msu' -Id 'KB123457' )
 
                 it 'should have called get-hotfix'{
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 it 'should return id="KB123456"'{
@@ -72,7 +72,7 @@ try
                 $getResult = (Test-TargetResource -Path 'C:\test.msu' -Id 'KB123456' )
 
                 it 'should have called get-hotfix'{
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 it 'should return $true'{
@@ -86,7 +86,7 @@ try
                 $getResult = (Test-TargetResource -Path 'C:\test.msu' -Id 'KB123457' )
 
                 it 'should have called get-hotfix'{
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
 
                 it 'should return $true'{

--- a/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsUpdateAgent.tests.ps1
@@ -42,7 +42,7 @@ try
     # The InModuleScope command allows you to perform white-box unit testing on the internal
     # (non-exported) code of a Script Module.
     InModuleScope $Global:DSCResourceName {
-        
+
         #region Pester Test Initialization
         $Global:mockedSearchResultWithUpdate = [PSCustomObject] @{
             Updates = @{
@@ -154,7 +154,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'null search result and disabled notification' {
@@ -208,7 +208,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'no updates property and disabled notification' {
@@ -260,7 +260,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'no updates and disabled notification' {
@@ -312,7 +312,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'no updates , disabled notification, and reboot required' {
@@ -364,7 +364,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'updates and disable notification' {
@@ -416,7 +416,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'updates and other notification' {
@@ -468,7 +468,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }
@@ -502,7 +502,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -531,7 +531,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -558,7 +558,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with no updates, disabled notification and reboot requirde' {
@@ -584,7 +584,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with updates and disabled notification' {
@@ -610,7 +610,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure Disable with updates and disable notification' {
@@ -646,7 +646,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure Disable with updates and other notification' {
@@ -682,7 +682,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -709,7 +709,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpdateNow = $false with updates and other notification' {
@@ -745,7 +745,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
         }
@@ -805,7 +805,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with no updates, mu and disabled notification' {
@@ -853,7 +853,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -904,7 +904,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -956,7 +956,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -1004,7 +1004,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with no updates, disabled notification and reboot required' {
@@ -1051,7 +1051,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with updates and disabled notification' {
@@ -1097,7 +1097,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure UpToDate with updates and disabled notification with reboot after install' {
@@ -1158,7 +1158,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
             Context 'Ensure Disable with updates and disable notification' {
@@ -1216,7 +1216,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -1276,7 +1276,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -1321,7 +1321,7 @@ try
                 }
 
                 it 'should have called the mock' {
-                    Assert-VerifiableMocks
+                    Assert-VerifiableMock
                 }
             }
 
@@ -1483,7 +1483,7 @@ try
             }
 
             it "should have called the mock" {
-                Assert-VerifiableMocks
+                Assert-VerifiableMock
             }
 
             it "should have created testdrive:\addservice2.txt" {
@@ -1603,7 +1603,7 @@ try
 
                 Assert-MockCalled -CommandName Write-Warning -Times 1 -Exactly -Scope It
             }
-            
+
             It 'Calls write-warning when Important updates are requested but not Security updates' {
                 $PropertiesToTest = @{
                     IsSingleInstance = 'Yes'


### PR DESCRIPTION
- Changes to xWindowsUpdate
  - Tests no longer fail on `Assert-VerifiableMocks`, these are now renamed
    to `Assert-VerifiableMock` (breaking change in Pester v4).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwindowsupdate/71)
<!-- Reviewable:end -->
