### PR TITLE
xWindowsUpdate: Fix tests failing after update in test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please check out common DSC Resources
   to `Assert-VerifiableMock` (breaking change in Pester v4).
 * README.md has been updated with correct description of the resources
   ([issue #58](https://github.com/PowerShell/xWindowsUpdate/issues/58)).
+* Updated appveyor.yml to use the correct parameters to call the test framework.
 
 ### 2.7.0.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: |
         $moduleName = 'xWindowsUpdate'
+        $mainModuleFolder = ".\"
         Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
         Invoke-AppveyorInstallTask
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,3 @@ deploy_script:
             -Type 'Wiki' `
             -MainModulePath $mainModuleFolder `
             -ResourceModuleName $moduleName
-
-
-
-
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,47 +1,45 @@
-#---------------------------------# 
-#      environment configuration  # 
-#---------------------------------# 
+#---------------------------------#
+#      environment configuration  #
+#---------------------------------#
 version: 2.5.{build}.0
-install: 
+install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: |
         $moduleName = 'xWindowsUpdate'
-        $mainModuleFolder = ".\"
         Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
         Invoke-AppveyorInstallTask
 
-#---------------------------------# 
-#      build configuration        # 
-#---------------------------------# 
+#---------------------------------#
+#      build configuration        #
+#---------------------------------#
 
 build: false
 
-#---------------------------------# 
-#      test configuration         # 
-#---------------------------------# 
+#---------------------------------#
+#      test configuration         #
+#---------------------------------#
 
 test_script:
     - ps: |
         Invoke-AppveyorTestScriptTask `
             -Type 'Default' `
-            -MainModulePath $mainModuleFolder `
             -ExcludeTag @() `
             -CodeCoverage `
             -CodeCovIo
-    
-#---------------------------------# 
-#      deployment configuration   # 
-#---------------------------------# 
 
-# scripts to run before deployment 
-deploy_script: 
+#---------------------------------#
+#      deployment configuration   #
+#---------------------------------#
+
+# scripts to run before deployment
+deploy_script:
   - ps: |
         Invoke-AppveyorAfterTestTask `
             -Type 'Wiki' `
             -MainModulePath $mainModuleFolder `
             -ResourceModuleName $moduleName
-        
-        
+
+
 
 
 


### PR DESCRIPTION
- Changes to xWindowsUpdate
  - Updated appveyor.yml to use the correct parameters to call the test framework.

Thanks to @johnf for reporting this in PR #31.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwindowsupdate/75)
<!-- Reviewable:end -->
