### PR TITLE
Fix Test-TargetResourceProperties - parameter name RetryAttempts not …

### DIFF
--- a/source/DSCResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
+++ b/source/DSCResources/MSFT_xWindowsUpdateAgent/MSFT_xWindowsUpdateAgent.psm1
@@ -850,6 +850,14 @@ function Test-TargetResourceProperties
         $Source,
 
         [Parameter()]
+        [System.Int32]
+        $RetryAttempts = -1,
+
+        [Parameter()]
+        [System.Int32]
+        $RetryDelay = -1,
+
+        [Parameter()]
         [System.Boolean]
         $UpdateNow
     )


### PR DESCRIPTION
BREAKING CHANGE: xWindowsUpdateAgent: Added RetryAttempts and RetryDelay parameters to Test-TargetResourceProperties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xwindowsupdate/97)
<!-- Reviewable:end -->
